### PR TITLE
Add input/output tensor shape capture for operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,21 @@ pip install -r requirements.txt
 Parse operators from a HuggingFace model:
 
 ```bash
-python simulate.py --model Qwen/Qwen3-Reranker-4B --ops
+python simulate.py --model Qwen/Qwen3-0.6B --ops
 ```
 
 ### Available Options
 
 - `--model MODEL`: HuggingFace model name (required)
-- `--ops`: Parse and display all operators with detailed information
+- `--ops`: Parse and display all operators with detailed information including input/output tensor shapes
 - `--deps`: Show dependency graph between operators
 - `--summary`: Show model summary with statistics
 
 ### Examples
 
-1. **Display all operators**:
+1. **Display all operators with tensor shapes**:
    ```bash
-   python simulate.py --model Qwen/Qwen3-Reranker-4B --ops
+   python simulate.py --model Qwen/Qwen3-0.6B --ops
    ```
 
 2. **Show model summary**:
@@ -61,6 +61,8 @@ For each operator, the tool displays:
 - Operator type (Linear, Embedding, LayerNorm, etc.)
 - Parameter count
 - Shape information (weight/bias shapes, input/output features)
+- **Input tensor shapes** (captured during forward pass)
+- **Output tensor shapes** (captured during forward pass)
 - Dependencies on other operators
 
 ### Summary (`--summary`)
@@ -78,7 +80,7 @@ For each operator, the tool displays:
 The tool works with any HuggingFace model that can be loaded with `AutoModel.from_pretrained()`. Tested with:
 - BERT variants (bert-base-uncased, distilbert-base-uncased)
 - GPT models (gpt2, gpt2-medium)
-- Qwen models (Qwen/Qwen3-Reranker-4B)
+- Qwen models (Qwen/Qwen3-0.6B, Qwen/Qwen3-Reranker-4B)
 - And many others
 
 ## Requirements


### PR DESCRIPTION
This PR implements the feature requested in issue #4 to display input and output tensor shapes for each operator.

## Changes Made

### Core Functionality
- **Added forward hooks** to capture actual tensor shapes during model execution
- **Enhanced operator display** to show input and output tensor shapes alongside existing information
- **Improved tensor shape extraction** with proper handling of various tensor types (single tensors, tuples, lists)

### Model Support
- **Updated examples** to use `Qwen/Qwen3-0.6B` as requested in the issue
- **Added tokenizer support** for creating appropriate sample inputs for different model types
- **Improved error handling** for edge cases in tensor shape extraction

### Documentation Updates
- Updated README.md to reflect new tensor shape functionality
- Updated help text and examples to use Qwen/Qwen3-0.6B
- Added documentation for the new input/output tensor shape features

## Example Output

For each operator, the tool now displays:
```
  layers.0.self_attn.q_proj
    Parameters: 2,097,152
    weight_shape: [2048, 1024]
    in_features: 1024
    out_features: 2048
    Input tensor shapes: [[1, 12, 1024]]
    Output tensor shapes: [[1, 12, 2048]]
    Dependencies: layers, layers.0, layers.0.self_attn
```

## Testing

Tested with:
- ✅ `Qwen/Qwen3-0.6B` (as requested in the issue)
- ✅ `distilbert-base-uncased` (for validation)
- ✅ All existing functionality (summary, dependencies, operators)

## Technical Implementation

The implementation uses PyTorch forward hooks to capture tensor shapes during a forward pass:

1. **Hook Registration**: Registers forward hooks on all modules
2. **Sample Input Creation**: Creates appropriate sample input using the model's tokenizer
3. **Forward Pass Execution**: Runs a forward pass to trigger hooks and capture shapes
4. **Shape Extraction**: Extracts and stores input/output tensor shapes
5. **Display Integration**: Integrates captured shapes into existing operator display

Resolves #4